### PR TITLE
chore: replace old GitHub Pages domain with new custom domain

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: This presentation provides an introduction to the
     GitHub Actions workflows.
 License: CC0 1.0 Universal
 URL: https://github.com/IndrajeetPatil/intro-to-ggstatsplot/,
-    https://indrajeetpatil.github.io/intro-to-ggstatsplot/
+    https://www.indrapatil.com/intro-to-ggstatsplot/
 BugReports: https://github.com/IndrajeetPatil/intro-to-ggstatsplot/issues
 Depends:
     bayestestR,

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This is a repository for presentation about the `{ggstatsplot}`.
 
 ## Links
 
-- 📊 [Presentation slides](https://indrajeetpatil.github.io/intro-to-ggstatsplot/)
-- 🌐 [Package website](https://indrajeetpatil.github.io/ggstatsplot/)
+- 📊 [Presentation slides](https://www.indrapatil.com/intro-to-ggstatsplot/)
+- 🌐 [Package website](https://www.indrapatil.com/ggstatsplot/)
 
 ## Setup
 

--- a/index.qmd
+++ b/index.qmd
@@ -36,7 +36,7 @@ lang: "en"
 dir: "ltr"
 image: "media/logo.png"
 image-alt: "Preview image for presentation about ggstatsplot statistical visualizations"
-canonical-url: "https://indrajeetpatil.github.io/intro-to-ggstatsplot/"
+canonical-url: "https://www.indrapatil.com/intro-to-ggstatsplot/"
 ---
 
 ```{r}
@@ -260,7 +260,7 @@ ggbetweenstats(iris, Species, Sepal.Length)
 ![](media/collage.jpeg)
 
 :::footer
-[Appendix](https://indrajeetpatil.github.io/intro-to-ggstatsplot/#/examples-of-other-functions) provides more details.
+[Appendix](https://www.indrapatil.com/intro-to-ggstatsplot/#/examples-of-other-functions) provides more details.
 :::
 
 # Promised Land
@@ -564,7 +564,7 @@ While re-architecting `{ggstatsplot}`, I started contributing upstream.
 
 ## Communication {.smaller}
 
-[Training material](https://indrajeetpatil.github.io/presentations/) on best practices in software/package development to support community contributions keeping in mind the diverse backgrounds of contributors.
+[Training material](https://www.indrapatil.com/presentations/) on best practices in software/package development to support community contributions keeping in mind the diverse backgrounds of contributors.
 
 ![](media/presentations.jpeg){.relative fig-align="center"}
 
@@ -615,7 +615,7 @@ Happy visualizing and reporting!
 
 ::: {style="text-align: center; font-size: 0.7em;"}
 
-Check out my other [slide decks](https://indrajeetpatil.github.io/presentations/) on software development best practices
+Check out my other [slide decks](https://www.indrapatil.com/presentations/) on software development best practices
 
 :::
 

--- a/meta-tags.html
+++ b/meta-tags.html
@@ -23,11 +23,11 @@
 />
 <meta
   property="og:image"
-  content="https://indrajeetpatil.github.io/intro-to-ggstatsplot/media/social-media-card.png"
+  content="https://www.indrapatil.com/intro-to-ggstatsplot/media/social-media-card.png"
 />
 <meta
   property="og:url"
-  content="https://indrajeetpatil.github.io/intro-to-ggstatsplot/"
+  content="https://www.indrapatil.com/intro-to-ggstatsplot/"
 />
 <meta property="og:type" content="website" />
 <meta property="og:site_name" content="ggstatsplot Introduction" />
@@ -44,6 +44,6 @@
 />
 <meta
   name="twitter:image"
-  content="https://indrajeetpatil.github.io/intro-to-ggstatsplot/media/social-media-card.png"
+  content="https://www.indrapatil.com/intro-to-ggstatsplot/media/social-media-card.png"
 />
 <meta name="twitter:creator" content="@patilindrajeets" />


### PR DESCRIPTION
## Summary

This PR updates all references from the old GitHub Pages domain to the new custom domain:

- **Old**: `https://indrajeetpatil.github.io/`
- **New**: `https://www.indrapatil.com/`

This is part of a bulk domain migration across all repositories.