### PR TITLE
chore: unify Google Analytics Measurement ID

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -11,7 +11,7 @@ format:
     help: true
     include-in-header: meta-tags.html
     link-external-newwindow: true
-    google-analytics: "G-H8PN2S7LEE"
+    google-analytics: "G-3BQ49J7KYH"
     code-link: true
     fig-dpi: 300
     fig-align: center

--- a/meta-tags.html
+++ b/meta-tags.html
@@ -1,7 +1,7 @@
 <!-- Google tag (gtag.js) -->
 <script
   async
-  src="https://www.googletagmanager.com/gtag/js?id=G-H8PN2S7LEE"
+  src="https://www.googletagmanager.com/gtag/js?id=G-3BQ49J7KYH"
 ></script>
 <script>
   window.dataLayer = window.dataLayer || [];
@@ -10,7 +10,7 @@
   }
   gtag("js", new Date());
 
-  gtag("config", "G-H8PN2S7LEE");
+  gtag("config", "G-3BQ49J7KYH");
 </script>
 
 <meta


### PR DESCRIPTION
Uses the root domain's Google Analytics Measurement ID for consolidated tracking across all presentations, as per best practices.