### PR TITLE
Remove obsolete Copilot instructions file

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,0 @@
-../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,8 @@
 # AGENTS.md
 
 Project-level instructions for AI coding agents working on this repository —
-Codex and other `AGENTS.md`-aware tools read this file directly; GitHub Copilot
-(code review and coding agent) reads it via the `.github/copilot-instructions.md`
-symlink, which GitHub resolves to this file's full content.
+Codex, GitHub Copilot (code review and coding agent), and other
+`AGENTS.md`-aware tools read this file directly.
 
 ## What this is
 


### PR DESCRIPTION
## Summary

- remove the obsolete `.github/copilot-instructions.md` file
- retain the root `AGENTS.md` as the single source of repository instructions
- update stale wording that described the former symlink path, where applicable

## Why

GitHub Copilot Code Review now supports agent instructions from a root `AGENTS.md` file directly, so the duplicate file or symlink is no longer necessary.

Documentation: https://docs.github.com/en/copilot/reference/custom-instructions-support

## Validation

- `git diff --check`
- confirmed `AGENTS.md` remains present and `.github/copilot-instructions.md` is removed
